### PR TITLE
Update proguard.cfg (#1693)

### DIFF
--- a/examples/android-proguard-example/proguard.cfg
+++ b/examples/android-proguard-example/proguard.cfg
@@ -15,7 +15,7 @@
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
--keep class * implements com.google.gson.TypeAdapter
+-keep class * extends com.google.gson.TypeAdapter
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer


### PR DESCRIPTION
TypeAdapter is an abstract class, and R8 warns about this during the build.